### PR TITLE
Remove Adrian's sensor server

### DIFF
--- a/content/apps/fetch_sensor_readings.md
+++ b/content/apps/fetch_sensor_readings.md
@@ -30,7 +30,6 @@ needs to abort and re-try.
 Sample servers are at:
 
 * `17-ffaa:0:1102,[192.33.93.177]:42003`
-* `17-ffaa:1:13,[192.168.1.79]:42003`
 
 Their readings can be fetched as follows:
 


### PR DESCRIPTION
The removed `sensorserver` lives in a user AS, should not be listed in the documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-tutorials/138)
<!-- Reviewable:end -->
