### PR TITLE
 Adapt docs for SCIONLab update

### DIFF
--- a/content/apps/access_camera.md
+++ b/content/apps/access_camera.md
@@ -20,7 +20,7 @@ See [Installation](../install/pkg.html#applications) for details.
 
 ## imagefetcher
 
-The `imagefetcher` application requests an image file from the server in an ad-hoc UDP-based protocol. The result is stored to a file (name optionally given on command line, otherwise uses name given by the server).
+The `imagefetcher` application requests an image file from the server in an ad-hoc UDP-based protocol. The result is stored to a file. The name for the output file can be given on command line, otherwise it uses the filename given by the server.
 
 Run the image fetcher application with the command
 

--- a/content/apps/access_camera.md
+++ b/content/apps/access_camera.md
@@ -20,27 +20,17 @@ See [Installation](../install/pkg.html#applications) for details.
 
 ## imagefetcher
 
-To use the image fetcher, you will need to specify the address of an image server. A sample image server that can be contacted by any client is set up at `17-ffaa:0:1102,[192.33.93.166]:42002`.
+The `imagefetcher` application requests an image file from the server in an ad-hoc UDP-based protocol. The result is stored to a file (name optionally given on command line, otherwise uses name given by the server).
 
-Images can be fetched like this:
-```
-scion-imagefetcher -c 17-ffaa:1:89,[127.0.0.1]:0 -s 17-ffaa:0:1102,[192.33.93.166]:42002
-```
-
-Here, `-s` specifies the image server whereas `-c` specifies your machine.
-The `-c` flag can be omitted if a SCION localhost address is configured. To do this, add your
-SCION host to the `/etc/hosts` file. Below you can see an example:
+Run the image fetcher application with the command
 
 ```
-# regular IPv4 hosts
-# ....
-
-# regular IPv6 hosts
-# ....
-
-# SCION hosts
-17-ffaa:0:1,[192.168.1.1]                               localhost
+scion-imagefetcher -s <server-address> [-output <filename.jpg>]
 ```
+
+Sample servers are at:
+
+* `17-ffaa:0:1102,[192.33.93.166]:42002`
 
 {% include alert type="Tip" content="
 `imagefetcher` is also available via the [webapp](../apps/as_visualization/webapp_apps.html).
@@ -50,14 +40,8 @@ SCION host to the `/etc/hosts` file. Below you can see an example:
 
 The `imageserver` application keeps looking for `.jpg` files in the current directory, and offers them for download to clients on the SCION network. The assumption is that the application is used in conjunction with an application that periodically writes an image to the file system. After an amount of time (currently set to 10 minutes), the image files are deleted to limit the amount of storage used.
 
-The image server is launched as follows:
+Run the image server application with the command
 
 ```
-scion-imageserver -s 17-ffaa:1:89,[127.0.0.1]:40002 &
-```
-Here `-s` specifies your server address. Again, it can be omitted by specifying a SCION localhost like above. The server then
-uses localhost to bind to. In this case, the port can be specified with the `-p` flag.
-
-```
-scion-imageserver -p 40002 &
+scion-imageserver -p <port>
 ```

--- a/content/apps/bwtester.md
+++ b/content/apps/bwtester.md
@@ -21,27 +21,12 @@ See [Installation](../install/pkg.html#applications) for details.
 You can run the bandwidth test client application as follows:
 
 ```
-scion-bwtestclient -c 17-ffaa:1:89,[127.0.0.1]:0 -s <server-address>
+scion-bwtestclient -s <server-address>
 ```
-
 
 The `-s` flag specifies the bandwidth server.
 Sample servers are installed at the various locations in the SCIONLab network, [see below](#scionlab-bandwidth-test-servers).
 
-The `-c` specifies your local address.
-The `-c` flag can be omitted if a SCION localhost address is configured. To do this, add your
-SCION host to the `/etc/hosts` file. Below you can see an example:
-
-```
-# regular IPv4 hosts
-# ....
-
-# regular IPv6 hosts
-# ....
-
-# SCION hosts
-17-ffaa:0:1,[192.168.1.1]                               localhost
-```
 
 ## Controlling the bandwidth
 The application supports specification of the test duration (up to 10 seconds), the packet size to be used (at least 4 bytes), the total number of packets that will be sent, and the target bandwidth. For instance, `5,100,10,1600bps` specifies that 10 packets of size 100 bytes will be sent over 5 seconds, resulting in a bandwidth of 1600bps. The question mark `?` character can be used as wildcard for any of these parameters. Its value is then computed according to the other parameters. The parameters for the test in the client-to-server direction are specified with `-cs`, and the server-to-client direction with `-sc`. So for instance to send 1 Mbps for 10 seconds from the client to the server, and 10 Mbps from the server to the client, you can use this command:
@@ -60,16 +45,11 @@ For more information run the application without arguments to print its usage.
 The server is started as follows:
 
 ```
-scion-bwtestserver -s 17-ffaa:0:1102,[192.33.93.177]:30100 &
+scion-bwtestserver -p 30100
 ```
 
-Here `-s` specifies your server address. Again, it can be omitted by specifying a SCION localhost like above. The server then
-uses localhost to bind to. In this case, the port can be specified with the `-p` flag.
+where `-p` specifies your server port.
 
-
-```
-scion-bwtestserver -p 30100 &
-```
 
 ## SCIONLab Bandwidth Test Servers
 

--- a/content/apps/bwtester.md
+++ b/content/apps/bwtester.md
@@ -24,11 +24,10 @@ You can run the bandwidth test client application as follows:
 scion-bwtestclient -s <server-address>
 ```
 
-The `-s` flag specifies the bandwidth server.
 Sample servers are installed at the various locations in the SCIONLab network, [see below](#scionlab-bandwidth-test-servers).
 
 
-## Controlling the bandwidth
+### Controlling the bandwidth
 The application supports specification of the test duration (up to 10 seconds), the packet size to be used (at least 4 bytes), the total number of packets that will be sent, and the target bandwidth. For instance, `5,100,10,1600bps` specifies that 10 packets of size 100 bytes will be sent over 5 seconds, resulting in a bandwidth of 1600bps. The question mark `?` character can be used as wildcard for any of these parameters. Its value is then computed according to the other parameters. The parameters for the test in the client-to-server direction are specified with `-cs`, and the server-to-client direction with `-sc`. So for instance to send 1 Mbps for 10 seconds from the client to the server, and 10 Mbps from the server to the client, you can use this command:
 
 ```

--- a/content/apps/fetch_sensor_readings.md
+++ b/content/apps/fetch_sensor_readings.md
@@ -22,54 +22,28 @@ See [Installation](../install/pkg.html#applications) for details.
 
 ## sensorfetcher
 
-The `sensorfetcher` application sends a 0-length SCION UDP packet to the `sensorserver` application
-to fetch the sensor readings. A string is returned containing all the sensor readings. To keep the
-application as simple as possible, no reliability is built in -- in case of packet loss, the user
-needs to abort and re-try.
+The `sensorfetcher` application is extremely simple. It sends a 0-length SCION UDP packet to the `sensorserver` application to fetch the sensor readings. A string is returned containing all the sensor readings. No reliability is built in -- in case of packet loss, the user needs to abort and re-try.
+
+Run the sensorfetcher application with the command
+
+```
+scion-sensorfetcher -s <server-address>
+```
 
 Sample servers are at:
 
 * `17-ffaa:0:1102,[192.33.93.177]:42003`
-
-Their readings can be fetched as follows:
-
-```
-scion-sensorfetcher -c 17-ffaa:1:89,[127.0.0.1]:0 -s 17-ffaa:0:1102,[192.33.93.177]:42003
-```
-
-Here, `-s` specifies the sensor server whereas `-c` specifies your machine.
-The `-c` flag can be omitted if a SCION localhost address is configured. To do this, add your
-SCION host to the `/etc/hosts` file. Below you can see an example:
-
-```
-# regular IPv4 hosts
-# ....
-
-# regular IPv6 hosts
-# ....
-
-# SCION hosts
-17-ffaa:0:1,[192.168.1.1]                               localhost
-```
 
 ## sensorserver
 
 We use sensors from Tinkerforge, and the `sensorreader` Python application to fetch the sensor values and write them to `stdout`. The `sensorserver` application collects the readings and serves them as a string to client requests. To start, we use the following command:
 
 ```
-scion-sensorreader | scion-sensorserver -s 17-ffaa:0:1102,[192.33.93.177]:42003 &
+scion-sensorreader | scion-sensorserver -p 42003
 ```
 
 If you do not have any sensor information available, then you can use a simple time application that reports the current time on your system:
 
 ```
-scion-timereader | scion-sensorserver -s 17-ffaa:0:1102,[192.33.93.177]:42003 &
-```
-
-In these examples,  `-s` specifies your server address. Again, it can be omitted by specifying a SCION localhost like above. The server then
-uses localhost to bind to. In this case, the port can be specified with the `-p` flag.
-
-```
-scion-sensorreader | scion-sensorserver -p 42003 &
-scion-timereader | scion-sensorserver -p 42003 &
+scion-timereader | scion-sensorserver -p 42003
 ```

--- a/content/apps/index.md
+++ b/content/apps/index.md
@@ -12,14 +12,13 @@ This section describes sample applications with SCION support. These application
 
 All of these applications require a running SCION endhost stack, i.e. a running
 SCION dispatcher and SCION daemon. This can be on the machine running your
-entire SCIONLab AS, or a separate end host in any SCION AS. Please refer to
-setup instructions the [end host configuration section](config/setup_endhost.html).
+entire SCIONLab AS or a separate end host. Please refer to setup instructions
+the [end host configuration section](../config/setup_endhost.html).
 
 ### Hostnames
-All applications allow to specify remote hosts either by full SCION addresses
-of the form `<ISD>-<AS>,[<IP>]` (plus `:<port>`, where applicable), or as a
-hostname.
-Hostnames are resolved by scanning the `/etc/hosts` file and by a RAINS lookup.
+All applications allow to specify remote hosts either by SCION addresses of the
+form `<ISD>-<AS>,[<IP>]`, or as a hostname.
+Hostnames are resolved by scanning the `/etc/hosts` file or by a RAINS lookup.
 
 Hosts can be added to `/etc/hosts` by adding lines like this:
 
@@ -29,9 +28,7 @@ Hosts can be added to `/etc/hosts` by adding lines like this:
 18-ffaa:0:11,[10.0.8.120]	server2
 ```
 
-The RAINS resolver address can be configured in `/etc/scion/rains.cfg`.
-This configuration file needs to contain the SCION address of the RAINS
-resolver, in the form `<ISD>-<AS>,[<IP>]`.
+Please refer to the [section on RAINS](rains.html) on how to configure name resolution using RAINS.
 
 ### Multiple local end host stacks
 

--- a/content/apps/index.md
+++ b/content/apps/index.md
@@ -5,3 +5,39 @@ has_children: true
 ---
 
 # Applications
+
+This section describes sample applications with SCION support. These applications are maintained in our [scion-apps GitHub repository](https://github.com/netsec-ethz/scion-apps).
+
+## Running
+
+All of these applications require a running SCION endhost stack, i.e. a running
+SCION dispatcher and SCION daemon. This can be on the machine running your
+entire SCIONLab AS, or a separate end host in any SCION AS. Please refer to
+setup instructions the [end host configuration section](config/setup_endhost.html).
+
+### Hostnames
+All applications allow to specify remote hosts either by full SCION addresses
+of the form `<ISD>-<AS>,[<IP>]` (plus `:<port>`, where applicable), or as a
+hostname.
+Hostnames are resolved by scanning the `/etc/hosts` file and by a RAINS lookup.
+
+Hosts can be added to `/etc/hosts` by adding lines like this:
+
+```
+# The following lines are SCION hosts
+17-ffaa:1:10,[10.0.8.100]	server1
+18-ffaa:0:11,[10.0.8.120]	server2
+```
+
+The RAINS resolver address can be configured in `/etc/scion/rains.cfg`.
+This configuration file needs to contain the SCION address of the RAINS
+resolver, in the form `<ISD>-<AS>,[<IP>]`.
+
+### Multiple local end host stacks
+
+When running multiple local ASes, e.g. during development, the address of the
+sciond corresponding to the desired local AS needs to be specified in the
+`SCION_DAEMON_ADDRESS` environment variable.
+
+Please refer to the documentation in the [scion-apps/README](https://github.com/netsec-ethz/scion-apps#running).
+

--- a/content/apps/rains.md
+++ b/content/apps/rains.md
@@ -11,9 +11,10 @@ nav_order: 70
 RAINS is an alternate protocol for Internet name resolution, designed as a replacement of the Domain Name System (DNS).
 The current implementation of RAINS can run on SCION, and serve SCION addresses.
 
+All of our apps can make use of RAINS to resolve hostnames, if a resolver is configured.
+
 If you want to run your own RAINS servers, please refer to the documentation in the [READMEs](https://github.com/netsec-ethz/rains).
 
-All of our apps can make use of RAINS to resolve hostnames, if a resolver is configured.
 
 ## Resolver config file
 
@@ -28,7 +29,7 @@ Create a file `/etc/scion/rains.cfg` and add a line with the address of a RAINS 
 RAINS contains a commandline tool to peek at names, similar to the well known `dig` tool for DNS.
 
 ### Setup
-Install the tool rdig, which allows you to make RAINS queries over SCION:
+Build from sources, requires an installation of go (~1.13).
 
 ```shell
 go get github.com/netsec-ethz/rains/cmd/rdig
@@ -42,15 +43,16 @@ rdig --help
 
 ### Making queries
 
-The following step assume that you are already running a SCION AS.
-To the resolver running in the Attachment Point:
+Prerequisite is a running SCION end host stack.
+
+To query a name on a RAINS resolver or name server at a known address/port, run:
 
 ```
-rdig @17-ffaa:0:1107,[192.33.93.195] ns1.snet. scion -p 5025
+rdig @<ISD-AS,IP> <name> scion -p <port>
 ```
 
-To a rainsd server for the zone node.snet. :
+For example, to send the a query for the name `ap17.node.snet` to the RAINS resolver configured above, run:
 
 ```
-rdig @17-ffaa:0:1107,[192.33.93.195] ap17.node.snet. scion -p 55553
+rdig @17-ffaa:0:1107,[192.33.93.195] ap17.node.snet. scion -p 5025
 ```

--- a/content/apps/rains.md
+++ b/content/apps/rains.md
@@ -6,13 +6,28 @@ nav_order: 70
 
 # RAINS, Another Internet Naming Service
 
-{% include alert type="Warning" content="This page has not been updated after the latest changes to SCIONLab and is out of date." %}
+{% include alert type="Warning" content="The RAINS infrastructure in SCIONLab is currently NOT available" %}
 
-RAINS is an alternate protocol for Internet name resolution, designed as a replacement of the Domain Name System (DNS) and is used in SCIONLab.
+RAINS is an alternate protocol for Internet name resolution, designed as a replacement of the Domain Name System (DNS).
+The current implementation of RAINS can run on SCION, and serve SCION addresses.
 
-## Setup
+If you want to run your own RAINS servers, please refer to the documentation in the [READMEs](https://github.com/netsec-ethz/rains).
 
-The following step assume that you are already running a SCION AS.
+All of our apps can make use of RAINS to resolve hostnames, if a resolver is configured.
+
+## Resolver config file
+
+Create a file `/etc/scion/rains.cfg` and add a line with the address of a RAINS resolver. For example, to use the RAINS resolver in the ETHZ AS in SCIONLab (**which is currently not available**), set this to:
+
+```
+17-ffaa:0:1107,[192.33.93.195]:5025
+```
+
+## rdig
+
+RAINS contains a commandline tool to peek at names, similar to the well known `dig` tool for DNS.
+
+### Setup
 Install the tool rdig, which allows you to make RAINS queries over SCION:
 
 ```shell
@@ -25,31 +40,17 @@ rdig --help
 ```
 
 
-Add some convenience functions to your shell to facilitate using rains with the SCION tools until rains support gets integrated natively:
+### Making queries
 
-```shell
-echo 'mydig() { rdig @17-ffaa:0:1107,[192.33.93.195] "$@" scionip4 -p 5025 | grep ":A:" | awk "{print \$6}" | sed "s/:scionip4://"; }' >> ~/.profile
-echo 'myHost() { echo `cat $SC/gen/ia | tr "_" ":"`,[127.0.0.1]; }' >> ~/.profile
-source ~/.profile
-```
-
-## Making queries
-
+The following step assume that you are already running a SCION AS.
 To the resolver running in the Attachment Point:
 
 ```
-rdig @17-ffaa:0:1107,[192.33.93.195] ns1.snet. scionip4 -p 5025
+rdig @17-ffaa:0:1107,[192.33.93.195] ns1.snet. scion -p 5025
 ```
 
 To a rainsd server for the zone node.snet. :
 
 ```
-rdig @17-ffaa:0:1107,[192.33.93.195] ap17.node.snet. scionip4 -p 55553
+rdig @17-ffaa:0:1107,[192.33.93.195] ap17.node.snet. scion -p 55553
 ```
-
-## Using scmp with rains
-
-```shell
-$SC/bin/scmp echo -c 3 -local `myHost` -remote `mydig ap17.node.snet.`
-```
-

--- a/content/config/check.md
+++ b/content/config/check.md
@@ -84,7 +84,7 @@ Run `scion.sh status` or `supervisor/supervisor.sh status`.
 
 Log files for the SCION services are located in `/var/log/scion`.
 
-Inspect the beacon server's log file using e.g. `less -f /var/log/scion/bs*.log`, to check that
+Inspect the control service's log file using e.g. `less -f /var/log/scion/cs*.log`, to check that
 
 *   Interfaces are considered `active`:
 
@@ -112,18 +112,8 @@ where a SCION address has the form `ISD-AS,[IP]`. An example of pinging a host i
     200 bytes from 20-ffaa:0:1404,[0.0.0.0] scmp_seq=1 time=381.763ms
 
 
-{% include alert type="note" content="
-Having to enter your own SCION address is a common theme with SCION tools. We hope we'll get
-rid of this somewhat arcane feature eventually.
-" %}
-
 {% include alert type="Tip" content="
 Check the topology map on the [SCIONLab homepage](https://www.scionlab.org) for an overview over the existing ASes and their addresses.
 " %}
-
-{% include alert type="Tip" content="
-If you're running the application on a local topology, make sure to specify the correct socket using the `-sciond` flag, e.g. by adding `-sciond /run/shm/sciond/sd1-ff00_0_110.sock`.
-" %}
-
 
 Passing this test is a condition sufficient to say that your AS works as expected. If it fails, please refer to [the troubleshooting section](../faq/troubleshooting.html).

--- a/content/config/check.md
+++ b/content/config/check.md
@@ -72,7 +72,7 @@ Finally, check that you can ping the address listed in `RemoteOverlay`.
 This should show all entries as green. If there are any failed services in this list, start [troubleshooting](../faq/troubleshooting.html)
 
 {% include alert type="note" content="
-Duplicated entries are bug in systemd which is fixed in Ubuntu 18.04. When using older platform, you can simply ignore them.
+`systemd list-dependencies` lists duplicated lines on Ubuntu 16.04, due to a bug in this systemd version. You can ignore this.
 " %}
 
 
@@ -87,11 +87,9 @@ Log files for the SCION services are located in `/var/log/scion`.
 Inspect the control service's log file using e.g. `less -f /var/log/scion/cs*.log`, to check that
 
 *   Interfaces are considered `active`:
-
     Check that the log mentions `Activated interface ...`, not followed by a later `interface went down`.
 
 *   Beacons are received successfully:
-
     Check that you find entries `Registered beacons ...`.
 
 

--- a/content/config/check.md
+++ b/content/config/check.md
@@ -99,11 +99,11 @@ Ping somebody! Run `scmp echo` to send an "SCMP echo request"; this is just like
 
 The syntax is:
 
-    scmp echo -local [source SCION address] -remote [destination SCION address]
+    scmp echo -remote [destination SCION address]
 
 where a SCION address has the form `ISD-AS,[IP]`. An example of pinging a host in the attachment point AS in Korea would look as follows:
 
-    $ scmp echo -local 17-ffaa:1:15b,[127.0.0.1] -remote 20-ffaa:0:1404,[0.0.0.0]
+    $ scmp echo -remote 20-ffaa:0:1404,[0.0.0.0]
     Using path:
       Hops: [17-ffaa:1:15b 1>169 17-ffaa:0:1107 1>4 17-ffaa:0:1102 2>2 17-ffaa:0:1103 4>8 17-ffaa:0:1101 11>3 19-ffaa:0:1302 1>7 19-ffaa:0:1301 3>5 18-ffaa:0:1201 3>5 20-ffaa:0:1401 7>1 20-ffaa:0:1403 3>47 20-ffaa:0:1404] Mtu: 1472
     200 bytes from 20-ffaa:0:1404,[0.0.0.0] scmp_seq=0 time=383.578ms

--- a/content/config/setup_endhost.md
+++ b/content/config/setup_endhost.md
@@ -4,7 +4,7 @@ parent: Configuration
 nav_order: 30
 ---
 
-# Configuring SCION end host
+# Configuring a SCION end host
 
 {% include alert type="note" content="
 You should go through this tutorial if you want to install SCION end host but do not want to run other SCION AS services on that machine.
@@ -16,7 +16,7 @@ Before proceeding you should already have SCION AS services available in your ne
 In this tutorial we will cover the steps necessary to configure a SCION end host in a SCIONLab AS.
 
 A SCION end host is a machine running SCION applications in a SCION AS, i.e. it is not a router and does not run any infrastructure services for the AS.
-An end host will communicate with the path and certificate servers of the AS to get paths and certificate information. For communication to hosts in different ASes, traffic will be sent to the SCION border routers of the AS.
+An end host will communicate with the control service of the AS to get paths and certificate information. For communication to hosts in different ASes, traffic will be sent to the SCION border routers of the AS.
 The end host knows the addresses for these services from a configuration file (`topology.json`).
 
 The software stack for a SCION end host application consists of the `dispatcher`, responsible for managing sockets and encapsulating/decapsulating SCION packets for IP/UDP overlay,
@@ -27,10 +27,9 @@ Compared to the perhaps more familiar software stack for IP, we can see some rou
 - `dispatcher`: corresponds to the kernels `socket` API
 - `sciond`: similar to a local caching DNS resolver daemon (like e.g. dnsmasq, unbound), except it's for paths and certificates, not for names
 
-## 1. Install SCION on end host
+## 1. Install SCION on the end host
 
 The software stack for a SCION end host consists of the `dispatcher` and the `sciond`, contained in the `scion-dispatcher` and `scion-daemon` packages.
-Just install an end host application that you're planning to run.
 
 On Debian-based OS run the following snippet to add the package repository:
 ```shell
@@ -53,19 +52,12 @@ When running SCION built from sources, the directory paths will be different (co
 The configuration downloaded from SCIONLab configures all SCION services to listen only on the localhost address by default.
 To run an end host on a different host, the services need to bind on an IP that is accessible from the end host.
 
-On the host running the AS services, locate the `topology.json` files in `/etc/scion/gen/`. In this configuration file, we change the occurrences of IP `127.0.0.1`
-to the hosts IP. In the service configuration toml files, we also replace the QUIC bind IP and omit the Prometheus metrics IP address, if we do not want to expose them.
+On the host running the AS services, locate the `topology.json` files in `/etc/scion/gen/`. In this configuration file, we change the occurrences of IP `127.0.0.1` to the hosts IP.
 
 ```
 export NODE_IP=example
 sed -i "s/127\.0\.0\.1/$NODE_IP/" /etc/scion/gen/ISD*/AS*/*/topology.json
-sed -i "s/Address = \"\[127\.0\.0\.1\]/Address = \"\[$NODE_IP\]/" /etc/scion/gen/ISD*/AS*/*/*.toml
 ```
-
-{% include alert type="note" content="
-Only `PathServer`, `CertificateServer` and the `InternalAddrs` of `BorderRouter` need to be accessible for the end host.
-This command also changes the address for the `BeaconServer` and the `CtrlAddr` of the `BorderRouter` as a bonus, for the sake of simplicity.
-" %}
 
 Restart your AS services by running
 
@@ -75,20 +67,12 @@ sudo systemctl restart scionlab.target
 
 ## 3. Extract and adapt end host configuration
 
-To create the configuration for the end host, we copy the configuration (modified in the previous step) from the node's `/etc/scion/gen` directory: we'll need the `dispatcher/` and the `ISD*/AS*/end host` directory.
+To create the configuration for the end host, we copy the relevant parts of the configuration (modified in the previous step) from the node's `/etc/scion/gen` directory: we'll need the `ISD*/AS*/endhost` and the `dispatcher/` sub-directories.
 
-The following snippet removes configuration of the SCION services from directory, keeping only the required part
+The following snippet copies exactly these parts of the SCION configuration to `/tmp/`:
 
 ```shell
-cp /etc/scion/gen /tmp/
-rm -r /tmp/gen/ISD*/AS*/{br,bs,ps,cs}*/
-```
-
-The Configuration of the `scion-daemon` also needs to be changed in order to use the IP address of the end host
-
-```
-export ENDHOST_IP=example
-sed -i "s/127\.0\.0\.1/$ENDHOST_IP/" /tmp/gen/ISD*/AS*/endhost/sd.toml
+cd /etc/scion/ && cp -r --parent gen/ISD*/AS*/endhost gen/dispatcher /tmp/
 ```
 
 At this moment `/tmp/gen` contains a full configuration needed for the SCION end host. You can use e.g. `scp` to install it in the `/etc/scion/` directory on the target machine.

--- a/content/faq/troubleshooting.md
+++ b/content/faq/troubleshooting.md
@@ -103,13 +103,23 @@ First clear the `/var/log/scion/` directory and restart. This often helps to fin
 
 #### Not receiving beacons
 
-Log of the beacon server (`/var/logs/scion/bs*.log`) does not contain recent entries referring to `Registered beacons`.
+Log of the control service (`/var/logs/scion/bs*.log`) does not contain recent entries referring to `Registered beacons`. This typically happens when the inter-AS links are not working correctly.
 
-As at the time of writing there are certain failure modes of the border routers that are hard to diagnose and are fixed with a simple restart, the first thing to try is to turn it off and on again:
+*   Check that the border router is (still) up
 
-```
-sudo systemctl restart scionlab.target
-```
+    If you are using VPN, a somewhat common issue is that the border router does not deal well with VPN tunnel interface disappearing intermittently. In particular, make sure that the VPN is started _before_ the border router.
+
+*   Double-check that `Public IP` configured for this link in the SCIONLab website is correct
+
+*   Check that the border router interfaces are `active`
+
+    Inspect the log file of control service (`/var/log/scion/cs*.log`) for messages on `Activated interface ...`.
+
+    The mechanism for activating interfaces is based on regular keep-alive messages, sent by the control service at 1s intervals over all configured AS-interfaces.
+    In a packet trace, we should see these keep-alive messages in both directions.
+    It can be useful to use `wireshark` or `tcpdump` to determine whether these packets are sent and received.
+    These small (~190 bytes) and regular packets are usually easy to spot in the packet trace.
+
 
 ## Getting help
 

--- a/content/install/src.md
+++ b/content/install/src.md
@@ -10,8 +10,8 @@ If you are planning to make modifications to the SCION implementation, you can b
 For developers' convenience, SCIONLab supports generating configurations that are compatible with the scripts and machinery intended to run SCION in a development environment.
 
 Building SCION from sources requires following a lengthy setup procedure and installing various development dependencies.
-The development setup is currently supported/documented for **Ubuntu 16.04 _only_**.
-It is possible to build SCION on other systems, but no guidance is provided. To keep it simple, just run Ubuntu 16.04 in a VM or container if you can't/don't want to set it up on your workstation.
+The development setup is currently supported/documented for **Ubuntu 16.04 or Ubuntu 18.04**.
+It is possible to build SCION on other systems, but no guidance is provided. To keep it simple, just run Ubuntu in a VM or container if you can't/don't want to set it up on your workstation.
 
 Please follow the instructions in the [GitHub README](https://github.com/netsec-ethz/scion/) to clone and build SCION.
 

--- a/index.md
+++ b/index.md
@@ -67,7 +67,7 @@ An autonomous system (AS) is a _network_ under the control of a single administr
 In SCION, ASes are connected only in well defined locations and links are defined by a provider/customer or a peering relation.
 
 Each AS is in charge of operating a set of control services that participate in the inter-domain routing control plane and provide essential path informations to the collection of devices connected to it, called end hosts (e.g Smartphones, Laptops and so on).
-At the same time, an AS is the the granularity of routing in SCION; very roughly, the path information carried in each packet header is described as a sequence of ASes that the packet should traverse to reach its destination.
+At the same time, an AS is the the granularity of routing in SCION; very roughly, the path information carried in each packet header describes a sequence of ASes that the packet must traverse to reach its destination.
 
 
 #### What does it mean to run an AS?

--- a/index.md
+++ b/index.md
@@ -69,7 +69,7 @@ In SCION, ASes are connected only in well defined locations and links are define
 Each AS is in charge of providing essential informations to the collection of devices connected to it, called end hosts (e.g Smartphones, Laptops and so on).
 The ASes in SCION are fundamental in the two main phases of the architecture: the *control* plane, which is the process responsible for discovering paths and making those paths available to end hosts; and the *data* plane, which is the process responsible for the transmission of the packets.
 
-For the control plane, each AS hosts different infrastructure services (beacon server, path server, certificate server and possibly others) that actually perform the process.
+For the control plane, each AS hosts different infrastructure services that actually perform the process. Most important is the main "control service" containing the functionality for beaconing, path database, and the control plane public key infrastructure.
 For the data plane, the inter-AS traffic is routed through the SCION border routers of the ASes along a path. SCION is agnostic about the intra-AS routing, typically ASes run IP internally.
 
 #### What does it mean to run an AS?

--- a/index.md
+++ b/index.md
@@ -66,11 +66,9 @@ SCIONLab is a global research network to test and experiment with the SCION inte
 An autonomous system (AS) is a _network_ under the control of a single administrative entity or domain.
 In SCION, ASes are connected only in well defined locations and links are defined by a provider/customer or a peering relation.
 
-Each AS is in charge of providing essential informations to the collection of devices connected to it, called end hosts (e.g Smartphones, Laptops and so on).
-The ASes in SCION are fundamental in the two main phases of the architecture: the *control* plane, which is the process responsible for discovering paths and making those paths available to end hosts; and the *data* plane, which is the process responsible for the transmission of the packets.
+Each AS is in charge of operating a set of control services that participate in the inter-domain routing control plane and provide essential path informations to the collection of devices connected to it, called end hosts (e.g Smartphones, Laptops and so on).
+At the same time, an AS is the the granularity of routing in SCION; very roughly, the path information carried in each packet header is described as a sequence of ASes that the packet should traverse to reach its destination.
 
-For the control plane, each AS hosts different infrastructure services that actually perform the process. Most important is the main "control service" containing the functionality for beaconing, path database, and the control plane public key infrastructure.
-For the data plane, the inter-AS traffic is routed through the SCION border routers of the ASes along a path. SCION is agnostic about the intra-AS routing, typically ASes run IP internally.
 
 #### What does it mean to run an AS?
 Running an AS means running the various AS control plane services and running border routers that connect the AS to other ASes.


### PR DESCRIPTION
* Update changed usage of applications
* Add section about common usage of applications (hostnames, environment variables)
* Adapt statements about control services to monolithic control server
* Update section on end host setup (actually got simpler due to using TCP)

Closes #139

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-tutorials/140)
<!-- Reviewable:end -->
