### PR TITLE
Android install instructions updated

### DIFF
--- a/content/install/android.md
+++ b/content/install/android.md
@@ -6,53 +6,31 @@ nav_order: 40
 
 # Running as an app (Android)
 
-{% include alert type="warning" title="Warning: Beta version" content="The SCION Android apps are still in beta and are not guaranteed to work." %}
+{% include alert type="warning" title="Warning: Beta version" content="The SCION Android app is in beta and has only been tested on selected Android devices." %}
+
+The SCION Android app allows you to host a SCION AS on your smartphone. This allows you to request and serve contents from and to the SCIONLab network. All SCION services are configured automatically based on your SCIONLab configuration. For detailed usage instructions, see below.
 
 ## Prerequisites
-- Android device with at least Android 7 (henceforth referred to as “endhost”)
-- Working scion AS with services set up to be reachable via IP from the endhost
-- SCION endhost app, [available on the Play Store](https://play.google.com/store/apps/details?id=org.scionlab.endhost)
-- SCION sensorfetcher app, [available on the Play Store](https://play.google.com/store/apps/details?id=org.scionlab.sensorfetcher) (optional)
+- Android device with at least Android 7.0
+- SCION app, [available on the Play Store](https://play.google.com/store/apps/details?id=org.scionlab.scion)
 
-## Import endhost configuration
-1. From your AS' `gen` directory, transfer the `endhost` directory onto your endhost's user accessible storage.
-2. In the endhost's `endhost` directory, find the `sciond.toml` or `sd.toml` file and make the following changes:
-  - In the `[sd]` section's `Public` value, replace your AS' IP address (or `127.0.0.1`) with your endhost's IP address.
-  - Either:
-    - Delete the `[logging.file]` section's entire `Path` assignment.
-    - Or replace the `[logging.file]` section's `Path` value with an absolute path that is accessible to you, e.g. `"/sdcard/logs/sd***.log"`.
-  - Either:
-    - Delete the `[trustDB]`/`[TrustDB]` section's entire `Connection` assignment.
-    - Or replace the `[trustDB]`/`[TrustDB]` section's `Connection` value with an absolute path that is accessible to you.
-  - Either:
-    - Delete the `[sd.PathDB]` section's entire `Connection` assignment.
-    - Or replace the `[sd.PathDB]` section's `Connection` value with an absolute path that is accessible to you.
-3. In the endhost's `endhost` directory, find the `topology.json` file and make sure that the endhost can reach the AS' services.
-This usually entails replacing the AS' IP address (or `127.0.0.1`) with the endhost's IP address.
+## Instructions
+To connect to the SCIONLab network with your Android phone, perform the following steps:
 
-## Starting the dispatcher and sciond
-Open the app and push the “Start dispatcher” button. Your notification drawer should now have a new permanent entry called “Dispatcher service”.
-Push the “Set endhost directory” button. In the dialog that appears, navigate to your endhost's `endhost` directory and press “OK”. Your notification drawer should now have a new permanent entry called “Sciond service”.
-The log files (usually) located in `/sdcard/Android/data/org.scionlab.endhost/files/logs/` should now get populated and not contain error messages.
-Apart from the `/sdcard/` prefix, the dispatcher logs are hardcoded to be in the aforementioned directory, while sciond's logs should either be in the aforementioned directory or where they've been configured to be in the previous step.
+1.  Register for a free user account on [scionlab.org](https://www.scionlab.org/).
+2.  In "[My ASes](https://www.scionlab.org/user/)", create a new SCIONLab AS with the following settings:
+    
+    *   _Label_: any value (is ignored by the app)
+    *   _Installation type_: Choose **SCION installation from sources**
+    *   _Attachment point_: Choose any attachment point you like, preferably the nearest to your location
+    *   _Use VPN_: You **must** check this box
+    *   _Public Port_: You **must not** change this from its default value 50000
+    
+    Alternatively, you can also use an existing SCIONLab AS if you adjust its settings as described above. In that case, also make sure that the _Active_ box is checked.
+3.  Once you have created the AS, you can download its configuration from "My ASes" as a _.tar.gz_ archive. Store this archive somewhere on your smartphone (e.g., on the SD card).
+4.  In the app, press the blue SCION button. The app will ask you to install _OpenVPN for Android_, which is required to connect to SCIONLab. _You do not need to start OpenVPN for Android manually, everything is set up by the SCION app._
+5.  Once _OpenVPN for Android_ is installed, press the SCION button again. You may have to grant permissions regarding VPN and media storage. Then choose the _.tar.gz_ SCIONLab configuration you have downloaded previously.
+6.  The app will now connect to SCIONLab and ping the given SCION address. To disconnect, press the SCION button again.
 
-## Testing connectivity with scmp
-In the text box, put in command line parameters for a call to the scmp application. These *have to be* newline-separated.
-It is advised to set the `-c` flag to a non-zero value since there is currently no way to gracefully *interrupt* the scmp process, once started.
-An example configuration would look as follows (mind the newlines!):
-```
-echo
--local
-[endhost address]
--remote
-19-ffaa:0:1303,[0.0.0.0]
--c
-1
-```
-Tap the “Start scmp” button to test your endhost's connectivity.
-You should notice movement in your log files.
-With access to your endhost's logcat, you could even see scmp's stdout and stderr outputs.
-If after some seconds, there is a notification titled “Scmp service” mentioning “Scmp returned with value 0”, you have SCION connectivity.
-
-## Testing connectivity with sensorfetcher
-Besides scmp being built into the SCION endhost app, the `sensorfetcher` has been ported to Android as a separate app. Both the local SCION address of the Android endhost and the remote SCION address of a running `sensorserver` have to be specified, as described [here](../apps/fetch_sensor_readings.html).
+## Troubleshooting
+In the app, you can view all log data from SCION. For more detailed information, have a look at the `/Android/data/org.scionlab.scion/files/` directory in the internal (or, on some devices, external) storage of your phone.

--- a/content/install/android.md
+++ b/content/install/android.md
@@ -12,7 +12,7 @@ The SCION Android app allows you to host a SCION AS on your smartphone. This all
 
 ## Prerequisites
 - Android device with at least Android 7.0
-- SCION app, [available on the Play Store](https://play.google.com/store/apps/details?id=org.scionlab.scion)
+- SCION app, [available on the Play Store](https://play.google.com/store/apps/details?id=org.scionlab.scion) (source code [available on GitHub](https://github.com/ekuiter/scion-android))
 
 ## Instructions
 To connect to the SCIONLab network with your Android phone, perform the following steps:


### PR DESCRIPTION
The Android app created by @TpmKranz and @veracl was further developed to include all SCION services, which allows to run an entire AS on an Android phone. The instructions have to be updated accordingly. (as discussed with @hausheer)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-tutorials/141)
<!-- Reviewable:end -->
