### PR TITLE
Fix filename for VPN config

### DIFF
--- a/content/config/check.md
+++ b/content/config/check.md
@@ -31,7 +31,7 @@ Check that the tunnel interface exists:
 
     sudo ip address show dev tun0
 
-Check that `/etc/openvpn/client.conf` exists.
+Check that `/etc/openvpn/client-scionlab-<attachment point ISD-AS>.conf` exists.
 
 Check that the OpenVPN client is up:
 

--- a/content/config/create_as.md
+++ b/content/config/create_as.md
@@ -62,8 +62,8 @@ The following options configure each "Provider link", that is, the options defin
     * you are **behind a NAT or firewall** and you cannot open/forward a chosen UDP port
     * you want to _"just make it work"_, as you'll need to know no further details about your network configuration
 
-    The configuration file will contain an OpenVPN configuration file named `client.conf`.
-    After extracting this file to `/etc/openvpn/`, you can start the tunnel by running `sudo systemctl start openvpn@client`.
+    The configuration file will contain an OpenVPN configuration file named `client-scionlab-<attachment point ISD-AS>.conf`.
+    After extracting this file to `/etc/openvpn/`, you can start the tunnel by running `sudo systemctl start openvpn@client-scionlab-<attachment point ISD-AS>`.
 
 *   Public IP Address, Bind IP Address
 

--- a/content/install/pkg.md
+++ b/content/install/pkg.md
@@ -62,10 +62,10 @@ configuration tarfile from the SCIONLab website and unpack it.
 
 1. Download the configuration tarfile from the SCIONLab coordination website.
 
-2. If using VPN, extract the `client.conf` to `/etc/openvpn/` and (re-)start OpenVPN
+2. If using VPN, extract the `client-scionlab-<attachment point ISD-AS>.conf` to `/etc/openvpn/` and (re-)start OpenVPN
 
         #!shell
-        sudo systemctl restart openvpn@client
+        sudo systemctl restart openvpn@client-scionlab-<attachment point ISD-AS>
 
 3. Extract the `gen/` subdirectory to `/etc/scion/`
 4. Enable the systemd units listed in `scionlab-services.txt` and restart SCION:

--- a/content/install/src.md
+++ b/content/install/src.md
@@ -33,9 +33,9 @@ on top of SCION.
 After having managed to build SCION and after [creating or modifying your AS](../config/create_as.html) in the SCIONLab coordination website, you can deploy the generated configuration to your machine.
 
 1. Download the configuration tarfile from the SCIONLab coordination website.
-2. If you plan on using a VPN, unpack the `client.conf` to `/etc/openvpn/` and start OpenVPN
+2. If you plan on using a VPN, unpack the `client-scionlab-<attachment point ISD-AS>.conf` to `/etc/openvpn/` and start OpenVPN
    ```shell
-   sudo systemctl restart openvpn@client
+   sudo systemctl restart openvpn@client-scionlab-<attachment point ISD-AS>
    ```
 3. Extract the `gen/` subdirectory to your `$SC` directory.
 4. Restart SCION


### PR DESCRIPTION
The old naming scheme was just `client.conf`, now its `client-scionlab-<attachment point ISD-AS>.conf` to allow for different config files for a User AS connected by VPN to multiple attachment points.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-tutorials/142)
<!-- Reviewable:end -->
