### PR TITLE
Providing way to run htmlproofer; minor fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'github-pages', group: :jekyll_plugins
+gem 'html-proofer', '~>3.15.3'

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ check:
 	$(JEKYLL) doctor
 	$(HTMLPROOF) --check-html \
 		--http-status-ignore 999 \
-		--internal-domains 127.0.0.1:8000 \
+		--internal-domains 127.0.0.1:8000,localhost:4000 \
 		--assume-extension \
 		_site
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ check:
 	$(JEKYLL) doctor
 	$(HTMLPROOF) --check-html \
 		--http-status-ignore 999 \
-		--internal-domains 127.0.0.1:8000,localhost:4000 \
+		--internal-domains 127.0.0.1:8000 \
 		--assume-extension \
 		_site
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+SHELL := /bin/bash
+BUNDLE := bundle
+JEKYLL := $(BUNDLE) exec jekyll
+HTMLPROOF := $(BUNDLE) exec htmlproofer
+PROJECT_DEPS := Gemfile
+
+.PHONY: all check install update build serve
+
+all: install serve
+
+check:
+	$(JEKYLL) doctor
+	$(HTMLPROOF) --check-html \
+		--http-status-ignore 999 \
+		--internal-domains 127.0.0.1:8000 \
+		--assume-extension \
+		_site
+
+install: $(PROJECT_DEPS)
+	$(BUNDLE) install --path _vendor/bundle
+
+update: $(PROJECT_DEPS)
+	$(BUNDLE) update
+
+build:
+	$(JEKYLL) build
+
+serve:
+	$(JEKYLL) serve

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ If you are making some generally useful changes, consider opening a PR in the up
 You can always look for broken links in the tutorials by running:
 
 ```shell
-wget --spider -r -nd -nv -l 3 -w 0 -o - https://netsec-ethz.github.io/scion-tutorials/ | grep -B1 'broken link!'
+wget --spider -r -nd -nv -l 3 -w 0 -o - https://docs.scionlab.org/ | grep -B1 'broken link!'
 ```
 
 Prior to merge to master it is always nice to check against our own repository. For that you need to enable Github Pages in your clone of `scion-tutorials`, and remembering that Github Pages are available only for the master branch, your commits would have to be pushed to your master. E.g.:

--- a/README.md
+++ b/README.md
@@ -12,17 +12,18 @@ The HTML website is generated using [Jekyll](http://www.jekyllrb.com/) with the 
 
 The webpage is rebuilt automatically when you push to GitHub. If you don't want to see the preview before pushing, you can stop reading now. (Using a Markdown-capable editor, such as the online editor online, might work well for this.)
 
-If you want to preview the docs locally, you need to install the `github-pages` gem (installs Jekyll in the same way as it is installed on GitHub pages):
+If you want to preview the docs locally, you need to install the `github-pages` and other
+supporting gems (installs Jekyll in the same way as it is installed on GitHub pages):
 ```shell
-bundle install --path _vendor/bundle
+make install
 ```
 
 (You need a working Ruby+bundler install first, install those from your OS's packages. You might have to install the 2.5 version specifically.)
 
-In order to generate the website, run in the activated virtualenv:
+In order to generate the website, run:
 
 ```shell
-bundle exec jekyll build
+make build
 ```
 
 The newly generated website will be placed in the `_site` directory.
@@ -30,7 +31,7 @@ The newly generated website will be placed in the `_site` directory.
 During the development phase, it is possible to run a local webserver and automatically refresh the website content. To do this, run:
 
 ```shell
-bundle exec jekyll serve
+make serve
 ```
 
 ## Adding a new page
@@ -84,12 +85,12 @@ We use the [just-the-docs theme](https://pmarsceill.github.io/just-the-docs/) as
 
 If you are making some generally useful changes, consider opening a PR in the upstream theme instead.
 
-## Check links
+## Check HTML and Links
 
-You can always look for broken links in the tutorials by running:
+You can always look for broken links and correct HTML in the tutorials by running:
 
 ```shell
-wget --spider -r -nd -nv -l 3 -w 0 -o - https://docs.scionlab.org/ | grep -B1 'broken link!'
+make check
 ```
 
 Prior to merge to master it is always nice to check against our own repository. For that you need to enable Github Pages in your clone of `scion-tutorials`, and remembering that Github Pages are available only for the master branch, your commits would have to be pushed to your master. E.g.:

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ If you are making some generally useful changes, consider opening a PR in the up
 You can always look for broken links and correct HTML in the tutorials by running:
 
 ```shell
-make check
+make serve
+make check # in a second terminal
 ```
 
 Prior to merge to master it is always nice to check against our own repository. For that you need to enable Github Pages in your clone of `scion-tutorials`, and remembering that Github Pages are available only for the master branch, your commits would have to be pushed to your master. E.g.:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SCION tutorials page
 
-The website is deployed on [Github Pages](https://netsec-ethz.github.io/scion-tutorials/).
+The website is deployed at [docs.scionlab.org/](https://docs.scionlab.org/) using [GitHub Pages](https://pages.github.com/).
 
 ## About
 

--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ aux_links:
     - "https://scion-architecture.net/"
   "Our GitHub":
     - "https://github.com/netsec-ethz/"
-footer_content: 'Copyright &copy 2019, Network Security Group, ETH Zurich'
+footer_content: "Copyright &copy; 2020, Network Security Group, ETH Zurich"
 url: https://docs.scionlab.org/
 
 # === visuals ===

--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@ aux_links:
   "Our GitHub":
     - "https://github.com/netsec-ethz/"
 footer_content: 'Copyright &copy 2019, Network Security Group, ETH Zurich'
+url: https://docs.scionlab.org/
 
 # === visuals ===
 remote_theme: pmarsceill/just-the-docs

--- a/content/apps/bat.md
+++ b/content/apps/bat.md
@@ -6,7 +6,7 @@ nav_order: 40
 
 # bat ("cURL for SCION")
 
-The [scion-apps/bat application](https://github.com/netsec-ethz/scion-apps/bat) is a clone of [astaxie/bat](https://github.com/astaxie/bat), a cURL-like tool for sending HTTP requests to webservers and retrieve information in a human-readable format. Our fork extends `bat` with native SCION support.
+The [scion-apps/bat application](https://github.com/netsec-ethz/scion-apps/tree/master/bat) is a clone of [astaxie/bat](https://github.com/astaxie/bat), a cURL-like tool for sending HTTP requests to webservers and retrieve information in a human-readable format. Our fork extends `bat` with native SCION support.
 
 ## Install
 

--- a/content/apps/remote_sig.md
+++ b/content/apps/remote_sig.md
@@ -11,7 +11,8 @@ The [SCION IP Gateway `SIG`](https://github.com/netsec-ethz/scion/tree/scionlab/
 ## Environment
 
 To test the SIG we will make use of the Vagrant configurations provided on [scionlab.org](https://scionlab.org/).
-Set up a Vagrant VM on a host A and a host B using the instructions from [Virtual machine with VPN](https://netsec-ethz.github.io/scion-tutorials/virtual_machine_setup/dynamic_ip/).
+Set up a Vagrant VM on a host A and a host B using the instructions for [running inside a VM]({% link content/install/vm.md %}) and [creating an AS
+ over VPN]({% link content/config/create_as.md %}).
 
 First, the SIG binary must be built. Please refer to the `building from source` docs page: https://docs.scionlab.org/content/install/src.html for instructions on setting up the proper environment (in particular setting up the Go workspace and ensuring you have the correct go version).
 


### PR DESCRIPTION
Added a Makefile to simplify running things, but mainly to conveniently run

```shell
$ make check
```

which executes the `bundle exec jekyll doctor` command and runs the htmlproofer gem against the currently existing `_site` directory.

Running htmlproofer led to some minor fixes:
* copyright symbol lacked a semicolon, browsers tolerated it anyway
* fixed outgoing link to `bat` folder in the `scion-apps` repo
* fixed a link to VM & VPN instructions for the SIG setup
* Implicitly set URL in configuration to appease the doctor

And also changed the main links to the docs at two places to reflect reality.

---

Side-note: The obnoxious `Invalid theme folder: _sass` warnings when running locally will vanish as soon as [this PR](https://github.com/github/pages-gem/pull/649) is merged into the GitHub Pages gem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-tutorials/153)
<!-- Reviewable:end -->
