### PR TITLE
Update/simplify SIG tutorial

### DIFF
--- a/content/apps/remote_sig.md
+++ b/content/apps/remote_sig.md
@@ -100,7 +100,7 @@ sudo -u scion sig -config=/etc/scion/gen/ISD${ISD}/AS${AS}/sig${ISD}-${AS}-1/sig
 ```
 
 {% include alert type="Tip" content="
-Now, you should already have connectivity between the SIGs. You can verify this, e.g. run `ping -I sigA 172.16.11.7` in host A,  and observe the arriving packets with `tcpdump -n -i sigB` on host B. However, there will not be replies to the pings yet.
+Now, you should already have connectivity between the SIGs. You can verify this, e.g. run `ping -I sigA 172.16.12.7` in host A,  and observe the arriving packets with `tcpdump -n -i sigB` on host B. However, there will not be replies to the pings yet.
 " %}
 
 ## Configuring Routing (simple)

--- a/content/install/pkg.md
+++ b/content/install/pkg.md
@@ -12,7 +12,7 @@ Prebuilt SCION packages are available for Ubuntu (or other Debian based systems)
 You can install SCION from our `.deb`-packages by running:
 
 ```shell
-sudo apt-get install apt-transport-https
+sudo apt-get install apt-transport-https ca-certificates
 echo "deb [trusted=yes] https://packages.netsec.inf.ethz.ch/debian all main" | sudo tee /etc/apt/sources.list.d/scionlab.list
 sudo apt-get update
 sudo apt-get install scionlab


### PR DESCRIPTION
Refer to new package installation instead of build instructions.

Shortened description of configuration by making use of packaged template files.

Simplify example setup; no dummy interfaces, just set address on the tunnel interface, use ip route instead of ip rule.
This setup is clearly less "powerful", i.e. it might not be clear how to go from here to a setup with IP routing.
Clearly, having the simple version first is friendlier -- not sure whether the "extended" version with routing with all the dummy interfaces needs be part of this guide.

Copy of #158, because this was accidentally merged (reverted by force push).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-tutorials/159)
<!-- Reviewable:end -->
