### PR TITLE
List outgoing NTP as connectivity requirement & add troubleshooting entry

### DIFF
--- a/content/faq/as_connectivity.md
+++ b/content/faq/as_connectivity.md
@@ -35,8 +35,10 @@ The ICMP connectivity is required for diagnosing the state of the network in cas
 | :------------- | :----------: | :-----------: | ---------------: |
 | ALL            |              | ESTABLISHED   |                  |
 | ICMP, ICMP6    |              | 0.0.0.0/0     | Heartbeats       |
+| UDP            | 123          | 0.0.0.0/0     | NTP Time Server Access (or provide an internally accessible NTP server) |
 | UDP            | 50000--50010 | 0.0.0.0/0 | SCION inter-AS connectivity |
 | UDP            | 30000--35000 | machines in the same SCION AS | SCION intra-AS connectivity |
 | TCP            | 80, 443      | 0.0.0.0/0     | Software updates, monitoring |
+
 
 Additionally, reliable DNS and NTP services must be accessible (but may be provided by the local network).

--- a/content/faq/troubleshooting.md
+++ b/content/faq/troubleshooting.md
@@ -120,6 +120,13 @@ Log of the control service (`/var/logs/scion/cs*.log`) does not contain recent e
     It can be useful to use `wireshark` or `tcpdump` to determine whether these packets are sent and received.
     These small (~190 bytes) and regular packets are usually easy to spot in the packet trace.
 
+*   Ensure the system clock is accurate. Drifts over ~15s can cause issues. Use `ntpd` (or resort to `htpdate` if outgoing
+    NTP cannot be unblocked in your infrastructure).
+    
+    If you find this to be the problem, but still have connectivity issues after 
+    resolving it, it might be due to stale entries in the PathDB. It might take a couple of hours until all the paths are invalidated. To accelerate this, stop the SCION services (`systemctl stop scionlab.target`),
+    remove the `/var/lib/scion/*path.db*` files and start the services again (`systemctl start scionlab.target`).
+
 
 ## Getting help
 

--- a/content/faq/troubleshooting.md
+++ b/content/faq/troubleshooting.md
@@ -120,7 +120,7 @@ Log of the control service (`/var/logs/scion/cs*.log`) does not contain recent e
     It can be useful to use `wireshark` or `tcpdump` to determine whether these packets are sent and received.
     These small (~190 bytes) and regular packets are usually easy to spot in the packet trace.
 
-*   Ensure the system clock is accurate. Drifts over ~15s can cause issues. Use `ntpd` (or resort to `htpdate` if outgoing
+*   Ensure the system clock is accurate. Drifts over 10s can cause issues. Use `ntpd` (or resort to `htpdate` if outgoing
     NTP cannot be unblocked in your infrastructure).
     
     If you find this to be the problem, but still have connectivity issues after 


### PR DESCRIPTION
- Missing NTP outgoing rule was likely an oversight.
- Adding a short blurb about time drift as a potential cause for connectivity issues.

![image](https://user-images.githubusercontent.com/1318986/95471187-f02f6080-0981-11eb-9a66-9ed7d2a6583e.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-tutorials/169)
<!-- Reviewable:end -->
