### PR TITLE
Remove reference to old Bind Port field

### DIFF
--- a/content/config/create_as.md
+++ b/content/config/create_as.md
@@ -91,12 +91,11 @@ available Attachment Points have an IPv6 address configured.
 " %}
 
 
-*   Public Port, Bind Port:
+*   Public Port:
 
     Choose a UDP port on which your Border Router will be reachable. We typically use ports in the range 50000-51000 by convention, but you're free to choose any other.
 
     If you are behind a NAT or firewall, make sure to open/forward the chosen port. For this you may need to contact your network administrator.
-    If you have a port forwarding rule that rewrites the port number, enter the local port number in the `Bind Port` field, otherwise leave it blank.
 
 
 ## Download and install configuration


### PR DESCRIPTION
The "Bind Port" field has been removed quite some time ago, but had
accidentally not been removed from the docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-tutorials/180)
<!-- Reviewable:end -->
