### PR TITLE
Update BitTorrent version to add reconnecting

### DIFF
--- a/content/apps/bittorrent.md
+++ b/content/apps/bittorrent.md
@@ -12,7 +12,7 @@ The [netsys-lab/bittorrent-over-scion](https://github.com/netsys-lab/bittorrent-
 
 To install `bittorrent-over-scion`, run:
 ```shell
-go install github.com/netsys-lab/bittorrent-over-scion@v1.0.2
+go install github.com/netsys-lab/bittorrent-over-scion@v1.0.3
 ```
 
 ## Usage


### PR DESCRIPTION
Hey all,

Matthias reported me a bug in our BitTorrent over SCION implementation that after some minutes of downloading, the connection to the dispatcher crashes. I've fixed this in bittorrent-over-scion v1.0.3 by reconnecting if this crash happens.

Best,
Marten

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-tutorials/191)
<!-- Reviewable:end -->
