### PR TITLE
Fixed typos

### DIFF
--- a/content/apps/as_visualization/webapp.md
+++ b/content/apps/as_visualization/webapp.md
@@ -50,7 +50,7 @@ scion-webapp \
 ```
 
 ## Browser AS Visualizations
-Several menu options are available at the top of each `webapp` page, which are outlined below. Each of the features below use your SCIONLab IA the the source address.
+Several menu options are available at the top of each `webapp` page, which are outlined below. Each of the features below use your SCIONLab IA as the source address.
 
 ### Health
 The Health tab is the landing page for `webapp` that will automatically test your SCIONLab configuration for configuration and communication health. Additional help is available in our [troubleshooting guide](../../faq/troubleshooting.html), if needed.

--- a/content/apps/rhine.md
+++ b/content/apps/rhine.md
@@ -150,7 +150,7 @@ There are several possible causes:
   `scion-bwtestclient` binary does not yet support DNS.
 - Your `scion-sdns` version is not running or misconfigured. Check its
   debug output.
-- The experimental autoritative name servers are both offline. Check if either of them
+- The experimental authoritative name servers are both offline. Check if either of them
   can be reached under their addresses via `scion ping
   "19-ffaa:1:fe4,127.0.0.1"` and `scion ping 17-ffaa:1:1008,[127.0.0.1]` respectively.
 

--- a/content/apps/scion-browser.md
+++ b/content/apps/scion-browser.md
@@ -9,7 +9,7 @@ nav_order: 100
 Please visit the [Browser Extension documentation](https://scion-browser-extension.readthedocs.io/en/latest/).
 
 # Deprecated setup
-If you are looking for the old setup, you can find the last artificats before deprecation here. Keep in mind that they are deprecated and may contain bugs.
+If you are looking for the old setup, you can find the last artifacts before deprecation here. Keep in mind that they are deprecated and may contain bugs.
 
 The following components are required:
 - [SCION Browser Extension](https://github.com/netsys-lab/scion-browser-extensions/tree/v0.4.0): Extensions for Chromium based browsers (Firefox later) that enable SCION connectivity


### PR DESCRIPTION
This pull request addresses minor typographical corrections across multiple documentation files.

Typographical corrections:

* Fixed "the the" to "as the" in the `content/apps/as_visualization/webapp.md` file to improve sentence readability.
* Corrected the spelling of "autoritative" to "authoritative" in the `content/apps/rhine.md` file for accuracy.
* Updated "artificats" to "artifacts" in the `content/apps/scion-browser.md` file to fix a typographical error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-tutorials/207)
<!-- Reviewable:end -->
